### PR TITLE
[CopyResourcesScript] add tvOS ibtool device-target for cocoapods PR #6063

### DIFF
--- a/install_add_pod/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_add_pod/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_circular_subspec_dependency/after/Pods/Target Support Files/Pods-SubSpecCircular/Pods-SubSpecCircular-resources.sh
+++ b/install_circular_subspec_dependency/after/Pods/Target Support Files/Pods-SubSpecCircular/Pods-SubSpecCircular-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_custom_build_configuration/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_custom_build_configuration/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_custom_module_map/after/Pods/Target Support Files/Pods-Example/Pods-Example-resources.sh
+++ b/install_custom_module_map/after/Pods/Target Support Files/Pods-Example/Pods-Example-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_custom_module_name/after/Pods/Target Support Files/Pods-Example/Pods-Example-resources.sh
+++ b/install_custom_module_name/after/Pods/Target Support Files/Pods-Example/Pods-Example-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_custom_workspace/after/Pods/Target Support Files/Pods-SampleApp_1/Pods-SampleApp_1-resources.sh
+++ b/install_custom_workspace/after/Pods/Target Support Files/Pods-SampleApp_1/Pods-SampleApp_1-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_custom_workspace/after/Pods/Target Support Files/Pods-SampleApp_2/Pods-SampleApp_2-resources.sh
+++ b/install_custom_workspace/after/Pods/Target Support Files/Pods-SampleApp_2/Pods-SampleApp_2-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_external_source/after/Pods/Target Support Files/Pods-iOS App/Pods-iOS App-resources.sh
+++ b/install_external_source/after/Pods/Target Support Files/Pods-iOS App/Pods-iOS App-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_framework_resources/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_framework_resources/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_framework_resources/after/Pods/Target Support Files/Pods-SampleAppTests/Pods-SampleAppTests-resources.sh
+++ b/install_framework_resources/after/Pods/Target Support Files/Pods-SampleAppTests/Pods-SampleAppTests-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_local_source/after/Pods/Target Support Files/Pods-iOS App/Pods-iOS App-resources.sh
+++ b/install_local_source/after/Pods/Target Support Files/Pods-iOS App/Pods-iOS App-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_multiple_targets/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_multiple_targets/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_multiple_targets/after/Pods/Target Support Files/Pods-SampleAppTests/Pods-SampleAppTests-resources.sh
+++ b/install_multiple_targets/after/Pods/Target Support Files/Pods-SampleAppTests/Pods-SampleAppTests-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_multiple_targets/after/Pods/Target Support Files/Pods-SampleApp_2/Pods-SampleApp_2-resources.sh
+++ b/install_multiple_targets/after/Pods/Target Support Files/Pods-SampleApp_2/Pods-SampleApp_2-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_new/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_new/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_no_dependencies/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_no_dependencies/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_non_objective_c_files/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_non_objective_c_files/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_podfile_callbacks/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_podfile_callbacks/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_podspec/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_podspec/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_remove_pod/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_remove_pod/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_resources/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_resources/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_resources_no_source_files/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_resources_no_source_files/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_search_paths_inheritance/after/Pods/Target Support Files/Pods-App/Pods-App-resources.sh
+++ b/install_search_paths_inheritance/after/Pods/Target Support Files/Pods-App/Pods-App-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_search_paths_inheritance/after/Pods/Target Support Files/Pods-Test/Pods-Test-resources.sh
+++ b/install_search_paths_inheritance/after/Pods/Target Support Files/Pods-Test/Pods-Test-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_subspecs/after/Pods/Target Support Files/Pods-OS X App/Pods-OS X App-resources.sh
+++ b/install_subspecs/after/Pods/Target Support Files/Pods-OS X App/Pods-OS X App-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_subspecs/after/Pods/Target Support Files/Pods-iOS App/Pods-iOS App-resources.sh
+++ b/install_subspecs/after/Pods/Target Support Files/Pods-iOS App/Pods-iOS App-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_subspecs_no_duplicate_prefix/after/Pods/Target Support Files/Pods-iOS App/Pods-iOS App-resources.sh
+++ b/install_subspecs_no_duplicate_prefix/after/Pods/Target Support Files/Pods-iOS App/Pods-iOS App-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_using_checkout_options/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_using_checkout_options/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/install_vendored_dynamic_framework/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/install_vendored_dynamic_framework/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/update_all/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/update_all/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/update_selected/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/update_selected/after/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -18,6 +18,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;


### PR DESCRIPTION
So far I've only updated the resources.sh, I do also have an example tvos framework project which will fail 'pod install' without this change with the following error:
<img width="974" alt="error ibtool" src="https://cloud.githubusercontent.com/assets/4517582/19568850/93781008-96f3-11e6-983f-192581d77ccd.png">

The example I have right now is a private production app, I could try making a minimal test example tomorrow.
@segiddins For making an example test project for the specs here, I create a new folder in the root and then add the example projectin 'before/DeveloperPods' right?
