### PR TITLE
Fixed specs for SWIFT_ACTIVE_COMPILATION_CONDITIONS

### DIFF
--- a/install_external_source/after/Pods/Pods.xcodeproj
+++ b/install_external_source/after/Pods/Pods.xcodeproj
@@ -116,6 +116,7 @@ Targets:
           PUBLIC_HEADERS_FOLDER_PATH: ''
           SDKROOT: iphoneos
           SKIP_INSTALL: 'YES'
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) "
         Base Configuration: PodTest.xcconfig
     - Release:
         Build Settings:
@@ -136,6 +137,7 @@ Targets:
           PUBLIC_HEADERS_FOLDER_PATH: ''
           SDKROOT: iphoneos
           SKIP_INSTALL: 'YES'
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) "
         Base Configuration: PodTest.xcconfig
 
 
@@ -183,6 +185,7 @@ Build Configurations:
       ONLY_ACTIVE_ARCH: 'YES'
       PROVISIONING_PROFILE_SPECIFIER: NO_SIGNING/
       STRIP_INSTALLED_PRODUCT: 'NO'
+      SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
       SYMROOT: ${SRCROOT}/../build
 - Release:
     Build Settings:

--- a/install_subspecs/after/Pods/Pods.xcodeproj
+++ b/install_subspecs/after/Pods/Pods.xcodeproj
@@ -211,6 +211,7 @@ Targets:
           PUBLIC_HEADERS_FOLDER_PATH: ''
           SDKROOT: iphoneos
           SKIP_INSTALL: 'YES'
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) "
         Base Configuration: PodTest-subspec_1.xcconfig
     - Release:
         Build Settings:
@@ -231,6 +232,7 @@ Targets:
           PUBLIC_HEADERS_FOLDER_PATH: ''
           SDKROOT: iphoneos
           SKIP_INSTALL: 'YES'
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) "
         Base Configuration: PodTest-subspec_1.xcconfig
 - PodTest-subspec_2:
     Build Phases:
@@ -275,6 +277,7 @@ Targets:
           PRODUCT_NAME: PodTest
           SDKROOT: macosx
           SKIP_INSTALL: 'YES'
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) "
           VERSIONING_SYSTEM: apple-generic
           VERSION_INFO_PREFIX: ''
         Base Configuration: PodTest-subspec_2.xcconfig
@@ -305,6 +308,7 @@ Targets:
           PRODUCT_NAME: PodTest
           SDKROOT: macosx
           SKIP_INSTALL: 'YES'
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) "
           VERSIONING_SYSTEM: apple-generic
           VERSION_INFO_PREFIX: ''
         Base Configuration: PodTest-subspec_2.xcconfig
@@ -355,6 +359,7 @@ Build Configurations:
       ONLY_ACTIVE_ARCH: 'YES'
       PROVISIONING_PROFILE_SPECIFIER: NO_SIGNING/
       STRIP_INSTALLED_PRODUCT: 'NO'
+      SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
       SYMROOT: ${SRCROOT}/../build
 - Release:
     Build Settings:


### PR DESCRIPTION
#105 didn't seem to fix all specs for CocoaPods/CocoaPods#6629, although it did pass locally 🤔. Anyways, this PR should fix the ones I missed.