### PR TITLE
Update for 64-bit architectures on Xcode 10

### DIFF
--- a/install_multiple_test_specs/after/Pods/Pods.xcodeproj
+++ b/install_multiple_test_specs/after/Pods/Pods.xcodeproj
@@ -109,7 +109,6 @@ Targets:
     - Debug:
         Build Settings:
           ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: 'NO'
-          ARCHS: "$(ARCHS_STANDARD_64_BIT)"
           CLANG_ENABLE_OBJC_WEAK: 'NO'
           CODE_SIGN_IDENTITY: ''
           CODE_SIGN_IDENTITY[sdk=appletvos*]: ''
@@ -143,7 +142,6 @@ Targets:
     - Release:
         Build Settings:
           ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: 'NO'
-          ARCHS: "$(ARCHS_STANDARD_64_BIT)"
           CLANG_ENABLE_OBJC_WEAK: 'NO'
           CODE_SIGN_IDENTITY: ''
           CODE_SIGN_IDENTITY[sdk=appletvos*]: ''
@@ -190,7 +188,6 @@ Targets:
     Build Configurations:
     - Debug:
         Build Settings:
-          ARCHS: "$(ARCHS_STANDARD_64_BIT)"
           CODE_SIGN_IDENTITY: ''
           CODE_SIGN_IDENTITY[sdk=appletvos*]: ''
           CODE_SIGN_IDENTITY[sdk=iphoneos*]: ''
@@ -221,7 +218,6 @@ Targets:
         Base Configuration: TestLib.xcconfig
     - Release:
         Build Settings:
-          ARCHS: "$(ARCHS_STANDARD_64_BIT)"
           CODE_SIGN_IDENTITY: ''
           CODE_SIGN_IDENTITY[sdk=appletvos*]: ''
           CODE_SIGN_IDENTITY[sdk=iphoneos*]: ''
@@ -264,7 +260,6 @@ Targets:
     Build Configurations:
     - Debug:
         Build Settings:
-          ARCHS: "$(ARCHS_STANDARD_64_BIT)"
           CODE_SIGNING_ALLOWED: 'YES'
           CODE_SIGNING_REQUIRED: 'YES'
           CODE_SIGN_IDENTITY: iPhone Developer
@@ -284,7 +279,6 @@ Targets:
         Base Configuration: TestLib.unit-unittests1.xcconfig
     - Release:
         Build Settings:
-          ARCHS: "$(ARCHS_STANDARD_64_BIT)"
           CODE_SIGNING_ALLOWED: 'YES'
           CODE_SIGNING_REQUIRED: 'YES'
           CODE_SIGN_IDENTITY: iPhone Developer
@@ -313,7 +307,6 @@ Targets:
     Build Configurations:
     - Debug:
         Build Settings:
-          ARCHS: "$(ARCHS_STANDARD_64_BIT)"
           CODE_SIGNING_ALLOWED: 'YES'
           CODE_SIGNING_REQUIRED: 'YES'
           CODE_SIGN_IDENTITY: iPhone Developer
@@ -334,7 +327,6 @@ Targets:
         Base Configuration: TestLib.unit-unittests2.xcconfig
     - Release:
         Build Settings:
-          ARCHS: "$(ARCHS_STANDARD_64_BIT)"
           CODE_SIGNING_ALLOWED: 'YES'
           CODE_SIGNING_REQUIRED: 'YES'
           CODE_SIGN_IDENTITY: iPhone Developer


### PR DESCRIPTION
the spec that changed is a recent addition and therefore has a higher object version - seems like a decent way to get coverage of both pre and post Xcode 10