### PR TITLE
[install_podfile_callbacks] Set build_settings flag on all targets.

### DIFF
--- a/install_podfile_callbacks/after/Pods/Pods.xcodeproj
+++ b/install_podfile_callbacks/after/Pods/Pods.xcodeproj
@@ -40,6 +40,7 @@ Targets:
           CODE_SIGN_IDENTITY[sdk=appletvos*]: ''
           CODE_SIGN_IDENTITY[sdk=iphoneos*]: ''
           CODE_SIGN_IDENTITY[sdk=watchos*]: ''
+          GCC_ENABLE_OBJC_GC: supported
           IPHONEOS_DEPLOYMENT_TARGET: '6.0'
           MACH_O_TYPE: staticlib
           OTHER_LDFLAGS: ''
@@ -58,6 +59,7 @@ Targets:
           CODE_SIGN_IDENTITY[sdk=appletvos*]: ''
           CODE_SIGN_IDENTITY[sdk=iphoneos*]: ''
           CODE_SIGN_IDENTITY[sdk=watchos*]: ''
+          GCC_ENABLE_OBJC_GC: supported
           IPHONEOS_DEPLOYMENT_TARGET: '6.0'
           MACH_O_TYPE: staticlib
           OTHER_LDFLAGS: ''

--- a/install_podfile_callbacks/before/Podfile
+++ b/install_podfile_callbacks/before/Podfile
@@ -9,8 +9,9 @@ pre_install do |installer|
 end
 
 post_install do |installer|
-  target = installer.pods_project.targets.first
-  target.build_configurations.each do |config|
-    config.build_settings['GCC_ENABLE_OBJC_GC'] = 'supported'
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['GCC_ENABLE_OBJC_GC'] = 'supported'
+    end
   end
 end


### PR DESCRIPTION
We can no longer rely on setting the first target because now both targets are accessible in the post_install hook.