### PR TITLE
Fix integration specs for #10027

### DIFF
--- a/install_vendored_static_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/install_vendored_static_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -50,12 +50,21 @@ select_slice() {
         break
       fi
 
+      # Verifies that the path contains the variant string (simulator or maccatalyst) if the variant is set.
+      if [[ -z "$target_variant" && "${paths[$i]}" == *"simulator"* || "${paths[$i]}" == *"maccatalyst"* ]]; then
+        matched_all_archs="0"
+        break
+      fi
+
       # This regex matches all possible variants of the arch in the folder name:
       # Let's say the folder name is: ios-armv7_armv7s_arm64_arm64e/CoconutLib.framework
       # We match the following: -armv7_, _armv7s_, _arm64_ and _arm64e/.
       # If we have a specific variant: ios-i386_x86_64-simulator/CoconutLib.framework
       # We match the following: -i386_ and _x86_64-
-      local target_arch_regex="[_\-]${target_arch}[\/_\-]"
+      # When the .xcframework wraps a static library, the folder name does not include
+      # any .framework. In that case, the folder name can be: ios-arm64_armv7
+      # We also match _armv7$ to handle that case.
+      local target_arch_regex="[_\-]${target_arch}([\/_\-]|$)"
       if ! [[ "${paths[$i]}" =~ $target_arch_regex ]]; then
         matched_all_archs="0"
         break

--- a/install_vendored_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/install_vendored_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -50,12 +50,21 @@ select_slice() {
         break
       fi
 
+      # Verifies that the path contains the variant string (simulator or maccatalyst) if the variant is set.
+      if [[ -z "$target_variant" && "${paths[$i]}" == *"simulator"* || "${paths[$i]}" == *"maccatalyst"* ]]; then
+        matched_all_archs="0"
+        break
+      fi
+
       # This regex matches all possible variants of the arch in the folder name:
       # Let's say the folder name is: ios-armv7_armv7s_arm64_arm64e/CoconutLib.framework
       # We match the following: -armv7_, _armv7s_, _arm64_ and _arm64e/.
       # If we have a specific variant: ios-i386_x86_64-simulator/CoconutLib.framework
       # We match the following: -i386_ and _x86_64-
-      local target_arch_regex="[_\-]${target_arch}[\/_\-]"
+      # When the .xcframework wraps a static library, the folder name does not include
+      # any .framework. In that case, the folder name can be: ios-arm64_armv7
+      # We also match _armv7$ to handle that case.
+      local target_arch_regex="[_\-]${target_arch}([\/_\-]|$)"
       if ! [[ "${paths[$i]}" =~ $target_arch_regex ]]; then
         matched_all_archs="0"
         break


### PR DESCRIPTION
Update integration specs to account for changes from https://github.com/CocoaPods/CocoaPods/pull/10027.

I haven't found any integration spec that actually compile the resulting project after `pod install`. The issue https://github.com/CocoaPods/CocoaPods/issues/10026 is only visible when compiling the resulting project.

I'd be happy to help to provide testing for that specific issue, but I would need guidance as to where such specs should end up.