### PR TITLE
Update XCFramework integration tests to copy the full architecture directory

### DIFF
--- a/install_vendored_static_library_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/install_vendored_static_library_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -144,12 +144,8 @@ install_xcframework() {
     mkdir -p "$destination"
   fi
 
-  if [[ "$package_type" == "library" ]]; then
-    # Libraries can contain headers, module maps, and a binary, so we'll copy everything in the folder over
-    copy_dir "$source/" "$destination"
-  elif [[ "$package_type" == "framework" ]]; then
-    copy_dir "$source" "$destination"
-  fi
+  copy_dir "$source/" "$destination"
+
   echo "Copied $source to $destination"
 }
 

--- a/install_vendored_static_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/install_vendored_static_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -144,14 +144,10 @@ install_xcframework() {
     mkdir -p "$destination"
   fi
 
-  if [[ "$package_type" == "library" ]]; then
-    # Libraries can contain headers, module maps, and a binary, so we'll copy everything in the folder over
-    copy_dir "$source/" "$destination"
-  elif [[ "$package_type" == "framework" ]]; then
-    copy_dir "$source" "$destination"
-  fi
+  copy_dir "$source/" "$destination"
+
   echo "Copied $source to $destination"
 }
 
-install_xcframework "${PODS_ROOT}/../BananaLib/CoconutLib.xcframework" "CoconutLib" "framework" "ios-i386_x86_64-simulator/CoconutLib.framework" "ios-armv7_arm64/CoconutLib.framework"
+install_xcframework "${PODS_ROOT}/../BananaLib/CoconutLib.xcframework" "CoconutLib" "framework" "ios-i386_x86_64-simulator" "ios-armv7_arm64"
 

--- a/install_vendored_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/install_vendored_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -144,14 +144,10 @@ install_xcframework() {
     mkdir -p "$destination"
   fi
 
-  if [[ "$package_type" == "library" ]]; then
-    # Libraries can contain headers, module maps, and a binary, so we'll copy everything in the folder over
-    copy_dir "$source/" "$destination"
-  elif [[ "$package_type" == "framework" ]]; then
-    copy_dir "$source" "$destination"
-  fi
+  copy_dir "$source/" "$destination"
+
   echo "Copied $source to $destination"
 }
 
-install_xcframework "${PODS_ROOT}/../BananaLib/CoconutLib.xcframework" "CoconutLib" "framework" "ios-x86_64-maccatalyst/CoconutLib.framework" "ios-i386_x86_64-simulator/CoconutLib.framework" "ios-armv7_arm64/CoconutLib.framework"
+install_xcframework "${PODS_ROOT}/../BananaLib/CoconutLib.xcframework" "CoconutLib" "framework" "ios-x86_64-maccatalyst" "ios-i386_x86_64-simulator" "ios-armv7_arm64"
 


### PR DESCRIPTION
Update XCFramework integration tests to reflect copying the full architecture directory rather than just the .framework.

This enables support for including debug symbols placed as a sibling of the .framework.

Full details in: https://github.com/CocoaPods/CocoaPods/issues/10111