### PR TITLE
Update integration specs for CocoaPods/CocoaPods#11707

### DIFF
--- a/install_vendored_static_library_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/install_vendored_static_library_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -20,26 +20,26 @@ variant_for_slice()
   "CoconutLib.xcframework/ios-arm64")
     echo ""
     ;;
-  "CoconutLib.xcframework/macos-x86_64")
-    echo ""
+  "CoconutLib.xcframework/ios-arm64_x86_64-simulator")
+    echo "simulator"
     ;;
   "CoconutLib.xcframework/ios-x86_64-maccatalyst")
     echo "maccatalyst"
     ;;
-  "CoconutLib.xcframework/watchos-arm64_32_armv7k")
+  "CoconutLib.xcframework/macos-x86_64")
+    echo ""
+    ;;
+  "CoconutLib.xcframework/tvos-arm64")
     echo ""
     ;;
   "CoconutLib.xcframework/tvos-arm64_x86_64-simulator")
     echo "simulator"
     ;;
+  "CoconutLib.xcframework/watchos-arm64_32_armv7k")
+    echo ""
+    ;;
   "CoconutLib.xcframework/watchos-arm64_i386_x86_64-simulator")
     echo "simulator"
-    ;;
-  "CoconutLib.xcframework/ios-arm64_x86_64-simulator")
-    echo "simulator"
-    ;;
-  "CoconutLib.xcframework/tvos-arm64")
-    echo ""
     ;;
   esac
 }
@@ -50,26 +50,26 @@ archs_for_slice()
   "CoconutLib.xcframework/ios-arm64")
     echo "arm64"
     ;;
-  "CoconutLib.xcframework/macos-x86_64")
-    echo "x86_64"
+  "CoconutLib.xcframework/ios-arm64_x86_64-simulator")
+    echo "arm64 x86_64"
     ;;
   "CoconutLib.xcframework/ios-x86_64-maccatalyst")
     echo "x86_64"
     ;;
-  "CoconutLib.xcframework/watchos-arm64_32_armv7k")
-    echo "arm64_32 armv7k"
+  "CoconutLib.xcframework/macos-x86_64")
+    echo "x86_64"
+    ;;
+  "CoconutLib.xcframework/tvos-arm64")
+    echo "arm64"
     ;;
   "CoconutLib.xcframework/tvos-arm64_x86_64-simulator")
     echo "arm64 x86_64"
     ;;
+  "CoconutLib.xcframework/watchos-arm64_32_armv7k")
+    echo "arm64_32 armv7k"
+    ;;
   "CoconutLib.xcframework/watchos-arm64_i386_x86_64-simulator")
     echo "arm64 i386 x86_64"
-    ;;
-  "CoconutLib.xcframework/ios-arm64_x86_64-simulator")
-    echo "arm64 x86_64"
-    ;;
-  "CoconutLib.xcframework/tvos-arm64")
-    echo "arm64"
     ;;
   esac
 }
@@ -153,5 +153,5 @@ install_xcframework() {
   echo "Copied $source to $destination"
 }
 
-install_xcframework "${PODS_ROOT}/../BananaLib/CoconutLib.xcframework" "BananaLib" "library" "ios-arm64" "ios-x86_64-maccatalyst" "ios-arm64_x86_64-simulator"
+install_xcframework "${PODS_ROOT}/../BananaLib/CoconutLib.xcframework" "BananaLib" "library" "ios-arm64" "ios-arm64_x86_64-simulator" "ios-x86_64-maccatalyst"
 

--- a/install_vendored_static_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/install_vendored_static_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -17,26 +17,26 @@ RSYNC_PROTECT_TMP_FILES=(--filter "P .*.??????")
 variant_for_slice()
 {
   case "$1" in
-  "CoconutLib.xcframework/tvos-x86_64-simulator")
-    echo "simulator"
-    ;;
-  "CoconutLib.xcframework/tvos-arm64")
-    echo ""
-    ;;
-  "CoconutLib.xcframework/watchos-i386-simulator")
-    echo "simulator"
-    ;;
-  "CoconutLib.xcframework/watchos-armv7k_arm64_32")
-    echo ""
-    ;;
-  "CoconutLib.xcframework/macos-x86_64")
+  "CoconutLib.xcframework/ios-armv7_arm64")
     echo ""
     ;;
   "CoconutLib.xcframework/ios-i386_x86_64-simulator")
     echo "simulator"
     ;;
-  "CoconutLib.xcframework/ios-armv7_arm64")
+  "CoconutLib.xcframework/macos-x86_64")
     echo ""
+    ;;
+  "CoconutLib.xcframework/tvos-arm64")
+    echo ""
+    ;;
+  "CoconutLib.xcframework/tvos-x86_64-simulator")
+    echo "simulator"
+    ;;
+  "CoconutLib.xcframework/watchos-armv7k_arm64_32")
+    echo ""
+    ;;
+  "CoconutLib.xcframework/watchos-i386-simulator")
+    echo "simulator"
     ;;
   esac
 }
@@ -44,26 +44,26 @@ variant_for_slice()
 archs_for_slice()
 {
   case "$1" in
-  "CoconutLib.xcframework/tvos-x86_64-simulator")
+  "CoconutLib.xcframework/ios-armv7_arm64")
+    echo "arm64 armv7"
+    ;;
+  "CoconutLib.xcframework/ios-i386_x86_64-simulator")
+    echo "i386 x86_64"
+    ;;
+  "CoconutLib.xcframework/macos-x86_64")
     echo "x86_64"
     ;;
   "CoconutLib.xcframework/tvos-arm64")
     echo "arm64"
     ;;
-  "CoconutLib.xcframework/watchos-i386-simulator")
-    echo "i386"
+  "CoconutLib.xcframework/tvos-x86_64-simulator")
+    echo "x86_64"
     ;;
   "CoconutLib.xcframework/watchos-armv7k_arm64_32")
     echo "arm64_32 armv7k"
     ;;
-  "CoconutLib.xcframework/macos-x86_64")
-    echo "x86_64"
-    ;;
-  "CoconutLib.xcframework/ios-i386_x86_64-simulator")
-    echo "i386 x86_64"
-    ;;
-  "CoconutLib.xcframework/ios-armv7_arm64")
-    echo "arm64 armv7"
+  "CoconutLib.xcframework/watchos-i386-simulator")
+    echo "i386"
     ;;
   esac
 }
@@ -147,5 +147,5 @@ install_xcframework() {
   echo "Copied $source to $destination"
 }
 
-install_xcframework "${PODS_ROOT}/../BananaLib/CoconutLib.xcframework" "BananaLib" "framework" "ios-i386_x86_64-simulator" "ios-armv7_arm64"
+install_xcframework "${PODS_ROOT}/../BananaLib/CoconutLib.xcframework" "BananaLib" "framework" "ios-armv7_arm64" "ios-i386_x86_64-simulator"
 

--- a/install_vendored_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/install_vendored_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -17,29 +17,29 @@ RSYNC_PROTECT_TMP_FILES=(--filter "P .*.??????")
 variant_for_slice()
 {
   case "$1" in
-  "CoconutLib.xcframework/tvos-arm64")
+  "CoconutLib.xcframework/ios-armv7_arm64")
     echo ""
-    ;;
-  "CoconutLib.xcframework/ios-x86_64-maccatalyst")
-    echo "maccatalyst"
     ;;
   "CoconutLib.xcframework/ios-i386_x86_64-simulator")
     echo "simulator"
     ;;
+  "CoconutLib.xcframework/ios-x86_64-maccatalyst")
+    echo "maccatalyst"
+    ;;
   "CoconutLib.xcframework/macos-x86_64")
     echo ""
     ;;
-  "CoconutLib.xcframework/ios-armv7_arm64")
+  "CoconutLib.xcframework/tvos-arm64")
     echo ""
     ;;
   "CoconutLib.xcframework/tvos-x86_64-simulator")
     echo "simulator"
     ;;
-  "CoconutLib.xcframework/watchos-i386-simulator")
-    echo "simulator"
-    ;;
   "CoconutLib.xcframework/watchos-armv7k_arm64_32")
     echo ""
+    ;;
+  "CoconutLib.xcframework/watchos-i386-simulator")
+    echo "simulator"
     ;;
   esac
 }
@@ -47,29 +47,29 @@ variant_for_slice()
 archs_for_slice()
 {
   case "$1" in
-  "CoconutLib.xcframework/tvos-arm64")
-    echo "arm64"
-    ;;
-  "CoconutLib.xcframework/ios-x86_64-maccatalyst")
-    echo "x86_64"
+  "CoconutLib.xcframework/ios-armv7_arm64")
+    echo "arm64 armv7"
     ;;
   "CoconutLib.xcframework/ios-i386_x86_64-simulator")
     echo "i386 x86_64"
     ;;
+  "CoconutLib.xcframework/ios-x86_64-maccatalyst")
+    echo "x86_64"
+    ;;
   "CoconutLib.xcframework/macos-x86_64")
     echo "x86_64"
     ;;
-  "CoconutLib.xcframework/ios-armv7_arm64")
-    echo "arm64 armv7"
+  "CoconutLib.xcframework/tvos-arm64")
+    echo "arm64"
     ;;
   "CoconutLib.xcframework/tvos-x86_64-simulator")
     echo "x86_64"
     ;;
-  "CoconutLib.xcframework/watchos-i386-simulator")
-    echo "i386"
-    ;;
   "CoconutLib.xcframework/watchos-armv7k_arm64_32")
     echo "arm64_32 armv7k"
+    ;;
+  "CoconutLib.xcframework/watchos-i386-simulator")
+    echo "i386"
     ;;
   esac
 }
@@ -153,5 +153,5 @@ install_xcframework() {
   echo "Copied $source to $destination"
 }
 
-install_xcframework "${PODS_ROOT}/../BananaLib/CoconutLib.xcframework" "BananaLib" "framework" "ios-x86_64-maccatalyst" "ios-i386_x86_64-simulator" "ios-armv7_arm64"
+install_xcframework "${PODS_ROOT}/../BananaLib/CoconutLib.xcframework" "BananaLib" "framework" "ios-armv7_arm64" "ios-i386_x86_64-simulator" "ios-x86_64-maccatalyst"
 


### PR DESCRIPTION
https://github.com/CocoaPods/CocoaPods/pull/11707 makes some changes to the order in which `switch` cases for the `install_xcframework.sh` shell script are generated in.

Changing the order of switch cases doesn't change the script's behavior, but we still require the integration specs to be updated to match the new case orders.