### PR TITLE
Fix potential Gatekeeper problems by removing the `LD_RUNPATH_SEARCH_PATHS` referencing outside the App bundle for macOS targets.

### DIFF
--- a/install_static_swift_modules/after/Pods/Target Support Files/Pods-Abstract Target-macOS Pods-Dynamic/Pods-Abstract Target-macOS Pods-Dynamic.debug.xcconfig
+++ b/install_static_swift_modules/after/Pods/Target Support Files/Pods-Abstract Target-macOS Pods-Dynamic/Pods-Abstract Target-macOS Pods-Dynamic.debug.xcconfig
@@ -3,7 +3,7 @@ CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO
 FRAMEWORK_SEARCH_PATHS = $(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/CustomModuleMapPod-framework-macOS" "${PODS_CONFIGURATION_BUILD_DIR}/MixedPod-framework-macOS" "${PODS_CONFIGURATION_BUILD_DIR}/ObjCPod-framework-macOS" "${PODS_CONFIGURATION_BUILD_DIR}/SwiftPod-framework-macOS"
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
 HEADER_SEARCH_PATHS = $(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/CustomModuleMapPod-framework-macOS/CustomModuleMapPod.framework/Headers" "${PODS_CONFIGURATION_BUILD_DIR}/MixedPod-framework-macOS/MixedPod.framework/Headers" "${PODS_CONFIGURATION_BUILD_DIR}/ObjCPod-framework-macOS/ObjCPod.framework/Headers" "${PODS_CONFIGURATION_BUILD_DIR}/SwiftPod-framework-macOS/SwiftPod.framework/Headers"
-LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frameworks' '@loader_path/Frameworks' "${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"
+LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frameworks' '@loader_path/Frameworks'
 LIBRARY_SEARCH_PATHS = $(inherited) "${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}" /usr/lib/swift
 OTHER_LDFLAGS = $(inherited) -framework "CustomModuleMapPod" -framework "MixedPod" -framework "ObjCPod" -framework "SwiftPod"
 OTHER_SWIFT_FLAGS = $(inherited) -D COCOAPODS

--- a/install_static_swift_modules/after/Pods/Target Support Files/Pods-Abstract Target-macOS Pods-Dynamic/Pods-Abstract Target-macOS Pods-Dynamic.release.xcconfig
+++ b/install_static_swift_modules/after/Pods/Target Support Files/Pods-Abstract Target-macOS Pods-Dynamic/Pods-Abstract Target-macOS Pods-Dynamic.release.xcconfig
@@ -3,7 +3,7 @@ CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO
 FRAMEWORK_SEARCH_PATHS = $(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/CustomModuleMapPod-framework-macOS" "${PODS_CONFIGURATION_BUILD_DIR}/MixedPod-framework-macOS" "${PODS_CONFIGURATION_BUILD_DIR}/ObjCPod-framework-macOS" "${PODS_CONFIGURATION_BUILD_DIR}/SwiftPod-framework-macOS"
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
 HEADER_SEARCH_PATHS = $(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/CustomModuleMapPod-framework-macOS/CustomModuleMapPod.framework/Headers" "${PODS_CONFIGURATION_BUILD_DIR}/MixedPod-framework-macOS/MixedPod.framework/Headers" "${PODS_CONFIGURATION_BUILD_DIR}/ObjCPod-framework-macOS/ObjCPod.framework/Headers" "${PODS_CONFIGURATION_BUILD_DIR}/SwiftPod-framework-macOS/SwiftPod.framework/Headers"
-LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frameworks' '@loader_path/Frameworks' "${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"
+LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frameworks' '@loader_path/Frameworks'
 LIBRARY_SEARCH_PATHS = $(inherited) "${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}" /usr/lib/swift
 OTHER_LDFLAGS = $(inherited) -framework "CustomModuleMapPod" -framework "MixedPod" -framework "ObjCPod" -framework "SwiftPod"
 OTHER_SWIFT_FLAGS = $(inherited) -D COCOAPODS


### PR DESCRIPTION
This PR updates specs for https://github.com/CocoaPods/CocoaPods/pull/11837.